### PR TITLE
[BUG] when entry links get copied by deepl from outside the site group they will not be copied

### DIFF
--- a/src/services/MapperService.php
+++ b/src/services/MapperService.php
@@ -57,7 +57,7 @@ class MapperService extends Component
     public function handleUnsupportedField(Element $element, string $handle)
     {
         if ($element->getFieldValue($handle) instanceof ElementQuery) {
-            return $element->getFieldValue($handle)->anyStatus()->ids();
+            return $element->getFieldValue($handle)->site('*')->anyStatus()->ids();
         }
         return $element->getFieldValue($handle);
     }


### PR DESCRIPTION
### Description


### Reason for this change

Issues in bioweb