### PR TITLE
FIX: fixes a bug where we accidentally copy over the siteId from the source instead of the target site

### DIFF
--- a/src/services/fields/hyper.php
+++ b/src/services/fields/hyper.php
@@ -4,10 +4,12 @@ namespace statikbe\deepl\services\fields;
 
 use craft\base\Component;
 use craft\base\Element;
+use craft\elements\Entry;
 use craft\models\Site;
 use statikbe\deepl\Deepl;
 use verbb\hyper\fields\HyperField;
 use verbb\hyper\models\LinkCollection;
+use verbb\hyper\base\ElementLink;
 
 class hyper extends Component
 {
@@ -28,6 +30,12 @@ class hyper extends Component
                     $translate
                 );
                 $link->linkText = $translation;
+            }
+            if ($link instanceof ElementLink) {
+                $entryExists = Entry::find()->siteId($targetSite->id)->id($link->linkValue)->status(null)->one();
+                if ($entryExists) {
+                    $link->linkSiteId = $targetSite->id;
+                }
             }
             $newLinks[] = $link;
         }


### PR DESCRIPTION

### Description
@SarahOorts Can explain this best but fixes issues when copying over a hyper field via deepl that the entry link on the field would point to the source site instead of the target site